### PR TITLE
issue : #4628 , Dark theme arrow property corrected

### DIFF
--- a/static/styles/themes/dark-theme.scss
+++ b/static/styles/themes/dark-theme.scss
@@ -492,6 +492,11 @@ textarea.form-control {
     border-color: #474747 !important;
 }
 
+.popover .arrow::after, .popover .arrow::before {
+    border-left-color: #151515 !important;
+    border-right-color: #151515 !important;
+}
+
 .popover {
     border-color: #464545 !important;
 }


### PR DESCRIPTION
Added the property to match the dark theme on the arrow button.
![arrow](https://user-images.githubusercontent.com/53165427/213871029-5ba50a22-7c41-4a81-b6c7-d3fd5ac554ba.JPG)



<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
